### PR TITLE
entrypoint.sh の修正

### DIFF
--- a/.github/actions/latex/entrypoint.sh
+++ b/.github/actions/latex/entrypoint.sh
@@ -9,9 +9,9 @@ dvipdfmx main.dvi
 res=`curl -H "Authorization: token $GITHUB_TOKEN" -X POST https://api.github.com/repos/$GITHUB_REPOSITORY/releases \
 -d "
 {
-  \"tag_name\": \"$(echo ${GITHUB_REF:10})\",
+  \"tag_name\": \"$(echo ${GITHUB_REF:11})\",
   \"target_commitish\": \"$GITHUB_SHA\",
-  \"name\": \"main.pdf $(echo ${GITHUB_REF:10})\",
+  \"name\": \"main.pdf $(echo ${GITHUB_REF:11})\",
   \"draft\": false,
   \"prerelease\": false
 }"`
@@ -23,4 +23,3 @@ rel_id=`echo ${res} | python3 -c 'import json,sys;print(json.load(sys.stdin)["id
 curl -H "Authorization: token $GITHUB_TOKEN" -X POST https://uploads.github.com/repos/$GITHUB_REPOSITORY/releases/${rel_id}/assets?name=main.pdf\
   --header 'Content-Type: application/pdf'\
   --upload-file main.pdf
-


### PR DESCRIPTION
[こちら](https://github.com/peano-system/nugitlecture/commit/126327efcc671f0933db3d73e5706b0d9bc16690/checks?check_suite_id=280917381)のエラーを見ると

>"message": "Validation Failed",
  "errors": [
    {
      "resource": "Release",
      "code": "custom",
      "field": "tag_name",
      "message": "tag_name is not a valid tag"
    },

となっており、`tag_name` の中身は `/master` となっていました。

>{
  "tag_name": "/master",
  "target_commitish": "9e5aab71a2256e87a936c4ef74ceef0574388f3e",
  "name": "main.pdf /master",
  "draft": false,
  "prerelease": false
}'

どうやら `tag_name` にスラッシュが入るとマズいようです。
https://stackoverflow.com/questions/26382234/what-names-are-valid-git-tags